### PR TITLE
[@mantine/hooks] use-fullscreen: custom ref state

### DIFF
--- a/src/mantine-hooks/src/use-fullscreen/use-fullscreen.ts
+++ b/src/mantine-hooks/src/use-fullscreen/use-fullscreen.ts
@@ -103,6 +103,13 @@ export function useFullscreen<T extends HTMLElement = any>() {
         onError: handleFullscreenError,
       });
     }
+    
+    if (_ref.current) {
+      return addEvents(_ref.current, {
+        onFullScreen: handleFullscreenChange,
+        onError: handleFullscreenError,
+      });
+    }
 
     return undefined;
   }, []);


### PR DESCRIPTION
Added a check to ensure a custom ref element toggles the fullscreen state